### PR TITLE
[Issue 7] Make SnackbarManager appearance accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A `Snack` is a model that represents a floating ephemeral alert or message to be
 - `reuseIdentifier`: A string for identifying a snack. This is of type `String?` and the default is nil.
 - `icon`: A small image to be displayed as part of the snack view. This is of type `UIImage?` and the default is nil.
 - `duration`: The total duration for which the snack will be displayed. The default is 4 seconds.
-- `appearance`: Sets the appearance of the `SnackView`. The default is `SnackView.Appearance()`
+- `appearance`: Sets the appearance of the `SnackView`. The default is `.default`.
 
 Two snacks are said to be equal if either the `reuseIdentifier` of both snacks are equal or the `title` and `message` of both snacks are equal. This is made possible by the snack’s conformance to both `Equatable` and `Hashable`.
 

--- a/Sources/YSnackbar/Manager/SnackbarManager+Appearance.swift
+++ b/Sources/YSnackbar/Manager/SnackbarManager+Appearance.swift
@@ -10,17 +10,20 @@ import UIKit
 
 extension SnackbarManager {
     /// Control animation duration and spacing
-    public final class Appearance {
+    public struct Appearance: Equatable {
         /// Animation duration on adding a snack. Default is `0.4`
-        public let addAnimationDuration: TimeInterval
+        public var addAnimationDuration: TimeInterval
         /// Animation duration on removing a snack. Default is `0.4`
-        public let removeAnimationDuration: TimeInterval
+        public var removeAnimationDuration: TimeInterval
         /// Spacing between snacks. Default is `16.0`
-        public let snackSpacing: CGFloat
+        public var snackSpacing: CGFloat
         /// Distance the content is inset from the superview. Default is `NSDirectionalEdgeInsets(all: 16.0)`
-        public let contentInset: NSDirectionalEdgeInsets
+        public var contentInset: NSDirectionalEdgeInsets
         /// Maximum width of a snack view. Default is `428.0`
-        public let maxSnackWidth: CGFloat
+        public var maxSnackWidth: CGFloat
+
+        /// Default appearance
+        public static let `default` = Appearance()
 
         /// Initializes a snackbar manager's appearance
         /// - Parameters:

--- a/Sources/YSnackbar/Manager/SnackbarManager.swift
+++ b/Sources/YSnackbar/Manager/SnackbarManager.swift
@@ -26,10 +26,18 @@ public class SnackbarManager {
         self.alignment = alignment
     }
 
-    /// Control animation duration and spacing
-    public var appearance = Appearance() {
+    internal var appearance: Appearance = .default {
         didSet {
             containerView?.appearance = appearance
+        }
+    }
+
+    /// Control animation duration and spacing
+    public static var appearance: Appearance {
+        get { sharedTop.appearance }
+        set {
+            sharedTop.appearance = newValue
+            sharedBottom.appearance = newValue
         }
     }
 
@@ -110,7 +118,7 @@ public class SnackbarManager {
 private extension SnackbarManager {
     func makeContainerViewIfNeeded() {
         if containerView == nil {
-            let containerView = SnackContainerView(alignment: alignment, appearance: Appearance())
+            let containerView = SnackContainerView(alignment: alignment, appearance: appearance)
             containerView.delegate = self
             self.containerView = containerView
         }

--- a/Sources/YSnackbar/Model/Snack.swift
+++ b/Sources/YSnackbar/Model/Snack.swift
@@ -22,7 +22,7 @@ open class Snack {
     public let icon: UIImage?
     /// The total duration for how long the snack to be displayed. Default is 4 seconds.
     public let duration: TimeInterval
-    /// Appearance for the snack view such as background color, shadow etc. Default is `SnackView.Appearance()`
+    /// Appearance for the snack view such as background color, shadow etc. Default is `.default`.
     public let appearance: SnackView.Appearance
 
     /// Initializes a `Snack`.
@@ -34,7 +34,7 @@ open class Snack {
     ///   - icon: image object to represent icon for the snack view. This is optional and default is nil
     ///   - duration: total duration for how long the snack to be displayed. Default is 4 seconds
     ///   - appearance: appearance for the snack view such as background color, shadow etc.
-    ///     Default is `SnackView.Appearance()`
+    ///     Default is `.default`.
     public init(
         alignment: Alignment = SnackbarManager.defaultAlignment,
         title: String? = nil,
@@ -42,7 +42,7 @@ open class Snack {
         reuseIdentifier: String? = nil,
         icon: UIImage? = nil,
         duration: TimeInterval = 4,
-        appearance: SnackView.Appearance = SnackView.Appearance()
+        appearance: SnackView.Appearance = .default
     ) {
         self.alignment = alignment
         self.title = title

--- a/Sources/YSnackbar/Views/SnackHostView.swift
+++ b/Sources/YSnackbar/Views/SnackHostView.swift
@@ -121,3 +121,11 @@ private extension SnackHostView {
         layer.shadowColor = elevation.color.cgColor
     }
 }
+
+/// Methods for unit testing
+internal extension SnackHostView {
+    /// Simulates a swipe for unit testing
+    func simulateSwipe() {
+        didSwipe(sender: UISwipeGestureRecognizer())
+    }
+}

--- a/Sources/YSnackbar/Views/SnackView+Appearance.swift
+++ b/Sources/YSnackbar/Views/SnackView+Appearance.swift
@@ -12,7 +12,7 @@ import YCoreUI
 
 extension SnackView {
     /// A collection of properties to set the appearance of the `SnackView`.
-    public final class Appearance {
+    public struct Appearance {
         /// A tuple consisting of `textColor` and `typography` for the title label.
         /// Default is `(.label, .systemLabel.bold)`.
         public let title: (textColor: UIColor, typography: Typography)
@@ -25,6 +25,9 @@ extension SnackView {
         public let elevation: Elevation
         /// `SnackView`'s layout properties such as spacing between views, corner radius. Default is `Layout()`.
         public let layout: Layout
+
+        /// Default appearance
+        public static let `default` = Appearance()
 
         /// Initializes a `Appearance`.
         /// - Parameters:

--- a/Tests/YSnackbarTests/Manager/SnackbarManagerBottomTests.swift
+++ b/Tests/YSnackbarTests/Manager/SnackbarManagerBottomTests.swift
@@ -221,24 +221,24 @@ final class SnackbarManagerBottomTests: XCTestCase {
         XCTAssertEqual(sut.appearance.contentInset, NSDirectionalEdgeInsets(all: 16.0))
         XCTAssertEqual(sut.appearance.snackSpacing, 16.0)
         XCTAssertEqual(sut.appearance.maxSnackWidth, 428.0)
+        XCTAssertEqual(sut.appearance, .default)
+        XCTAssertEqual(sut.containerView?.appearance, .default)
     }
 
     func test_newAppearanceOnAddingSnackAtTheBottom() {
         let sut = makeSUT()
-
-        sut.appearance = SnackbarManager.Appearance(
+        let appearance = SnackbarManager.Appearance(
             addAnimationDuration: 0.7,
             removeAnimationDuration: 0.7,
             snackSpacing: 24.0,
             contentInset: NSDirectionalEdgeInsets(all: 24.0)
         )
+        sut.appearance = appearance
 
         sut.add(snack: Snack(message: ""))
 
-        XCTAssertEqual(sut.appearance.addAnimationDuration, 0.7)
-        XCTAssertEqual(sut.appearance.removeAnimationDuration, 0.7)
-        XCTAssertEqual(sut.appearance.contentInset, NSDirectionalEdgeInsets(all: 24.0))
-        XCTAssertEqual(sut.appearance.snackSpacing, 24.0)
+        XCTAssertEqual(sut.appearance, appearance)
+        XCTAssertEqual(sut.containerView?.appearance, appearance)
     }
 }
 
@@ -249,7 +249,7 @@ extension SnackbarManagerBottomTests {
         sut.removeAllSnack()
 
         if loadContainerView {
-            let containerView = SnackContainerViewSpy(alignment: .bottom, appearance: SnackbarManager.Appearance())
+            let containerView = SnackContainerViewSpy(alignment: .bottom, appearance: .default)
             sut.updateContainerView(containerView)
         } else {
             sut.didRemoveContainerView()

--- a/Tests/YSnackbarTests/Manager/SnackbarManagerTests.swift
+++ b/Tests/YSnackbarTests/Manager/SnackbarManagerTests.swift
@@ -1,0 +1,30 @@
+//
+//  SnackbarManagerTests.swift
+//  YSnackbar
+//
+//  Created by Mark Pospesel on 3/22/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YSnackbar
+
+final class SnackbarManagerTests: XCTestCase {
+    func test_defaultAppearance() {
+        XCTAssertEqual(SnackbarManager.appearance, .default)
+        XCTAssertEqual(SnackbarManager.sharedTop.appearance, .default)
+        XCTAssertEqual(SnackbarManager.sharedBottom.appearance, .default)
+    }
+
+    func test_setAppearance_changesTopAndBottomManagers() {
+        defer { SnackbarManager.appearance = .default }
+        let spacing = CGFloat(Int.random(in: 0..<16))
+        let appearance = SnackbarManager.Appearance(snackSpacing: spacing)
+
+        SnackbarManager.appearance.snackSpacing = spacing
+
+        XCTAssertEqual(SnackbarManager.appearance, appearance)
+        XCTAssertEqual(SnackbarManager.sharedTop.appearance, appearance)
+        XCTAssertEqual(SnackbarManager.sharedBottom.appearance, appearance)
+    }
+}

--- a/Tests/YSnackbarTests/Manager/SnackbarManagerTopTests.swift
+++ b/Tests/YSnackbarTests/Manager/SnackbarManagerTopTests.swift
@@ -260,24 +260,28 @@ final class SnackbarManagerTopTests: XCTestCase {
         XCTAssertEqual(sut.appearance.contentInset, NSDirectionalEdgeInsets(all: 16.0))
         XCTAssertEqual(sut.appearance.snackSpacing, 16.0)
         XCTAssertEqual(sut.appearance.maxSnackWidth, 428.0)
+        XCTAssertEqual(sut.appearance, .default)
+        XCTAssertEqual(sut.containerView?.appearance, .default)
     }
 
     func test_newAppearanceOnAddingSnackAtTheTop() {
         let sut = makeSUT()
-
-        sut.appearance = SnackbarManager.Appearance(
+        let appearance = SnackbarManager.Appearance(
             addAnimationDuration: 0.7,
             removeAnimationDuration: 0.7,
             snackSpacing: 24.0,
             contentInset: NSDirectionalEdgeInsets(all: 24.0)
         )
 
+        sut.appearance.addAnimationDuration = 0.7
+        sut.appearance.removeAnimationDuration = 0.7
+        sut.appearance.snackSpacing = 24.0
+        sut.appearance.contentInset = NSDirectionalEdgeInsets(all: 24.0)
+
         sut.add(snack: Snack(message: ""))
 
-        XCTAssertEqual(sut.appearance.addAnimationDuration, 0.7)
-        XCTAssertEqual(sut.appearance.removeAnimationDuration, 0.7)
-        XCTAssertEqual(sut.appearance.contentInset, NSDirectionalEdgeInsets(all: 24.0))
-        XCTAssertEqual(sut.appearance.snackSpacing, 24.0)
+        XCTAssertEqual(sut.appearance, appearance)
+        XCTAssertEqual(sut.containerView?.appearance, appearance)
     }
 }
 
@@ -288,7 +292,7 @@ extension SnackbarManagerTopTests {
         sut.removeAllSnack()
 
         if loadContainerView {
-            let containerView = SnackContainerViewSpy(alignment: .top, appearance: SnackbarManager.Appearance())
+            let containerView = SnackContainerViewSpy(alignment: .top, appearance: .default)
             sut.updateContainerView(containerView)
         } else {
             sut.didRemoveContainerView()

--- a/Tests/YSnackbarTests/Model/SnackEquatableTests.swift
+++ b/Tests/YSnackbarTests/Model/SnackEquatableTests.swift
@@ -106,7 +106,7 @@ private extension SnackEquatableTests {
             duration: duration
         )
 
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
 
         return sut
     }

--- a/Tests/YSnackbarTests/Model/SnackHashableTests.swift
+++ b/Tests/YSnackbarTests/Model/SnackHashableTests.swift
@@ -106,7 +106,7 @@ private extension SnackHashableTests {
             duration: duration
         )
 
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
 
         return sut
     }

--- a/Tests/YSnackbarTests/Model/SnackTests.swift
+++ b/Tests/YSnackbarTests/Model/SnackTests.swift
@@ -85,14 +85,14 @@ private extension SnackTests {
             duration: duration
         )
 
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
         
         return sut
     }
 
     func makeSUT(message: String, file: StaticString = #filePath, line: UInt = #line) -> Snack {
         let sut = Snack(message: message)
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
         return sut
     }
 }

--- a/Tests/YSnackbarTests/Test Helpers/XCTestCase+MemoryLeakTracking.swift
+++ b/Tests/YSnackbarTests/Test Helpers/XCTestCase+MemoryLeakTracking.swift
@@ -9,7 +9,7 @@
 import XCTest
 
 extension XCTestCase {
-    func trackForMemoryLeaks(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
+    func trackForMemoryLeak(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
         addTeardownBlock { [weak instance] in
             XCTAssertNil(
                 instance,

--- a/Tests/YSnackbarTests/Views/SnackContainerViewTests.swift
+++ b/Tests/YSnackbarTests/Views/SnackContainerViewTests.swift
@@ -9,6 +9,9 @@
 import XCTest
 @testable import YSnackbar
 
+// OK to have lots of test cases
+// swiftlint:disable file_length
+
 final class SnackContainerViewTests: XCTestCase {
     func test_initWithCoder() throws {
         XCTAssertNil(SnackContainerView(coder: try makeCoder(for: UIView())))
@@ -210,6 +213,30 @@ final class SnackContainerViewTests: XCTestCase {
         XCTAssertEqual(filteredSnackViews, [hostViews[0], hostViews[2], hostViews[1]])
     }
 
+    func test_rearrangeSecondSnackViewFromTop_movesSecondItemToTheBottom() {
+        let sut = makeSUT(alignment: .top)
+        let hostViews = makeHostViews()
+
+        sut.addHostViews(hostViews)
+
+        _ = sut.rearrangeHostView(at: 1) { }
+
+        let filteredSnackViews = sut.hostViews.compactMap { $0 }
+        XCTAssertEqual(filteredSnackViews, [hostViews[0], hostViews[2], hostViews[1]])
+    }
+
+    func test_rearrangeSecondSnackViewFromBottom_movesSecondItemToTheTop() {
+        let sut = makeSUT(alignment: .bottom)
+        let hostViews = makeHostViews()
+
+        sut.addHostViews(hostViews)
+
+        _ = sut.rearrangeHostView(at: 1) { }
+
+        let filteredSnackViews = sut.hostViews.compactMap { $0 }
+        XCTAssertEqual(filteredSnackViews, [hostViews[1], hostViews[2], hostViews[0]])
+    }
+
     func test_rearrangeLastSnackViewFromBottom_doesNotChangeSnackPosition() {
         let sut = makeSUT(alignment: .bottom)
         let hostViews = makeHostViews()
@@ -255,15 +282,20 @@ final class SnackContainerViewTests: XCTestCase {
         let sut = makeSUT(alignment: .bottom)
         let hostView1 = makeHostViews()[0]
         let hostView2 = makeHostViews()[1]
+        let hostView3 = makeHostViews()[2]
 
-        sut.addHostViews([hostView1, hostView2])
+        sut.addHostViews([hostView1, hostView2, hostView3])
+        XCTAssertNotNil(sut.window)
+
+        sut.snackViewToBeRemoved = hostView2
+        sut.removeHostView(at: 1)
         XCTAssertNotNil(sut.window)
 
         sut.snackViewToBeRemoved = hostView1
         sut.removeHostView(at: 0)
         XCTAssertNotNil(sut.window)
 
-        sut.snackViewToBeRemoved = hostView2
+        sut.snackViewToBeRemoved = hostView3
         sut.removeHostView(at: 0)
         XCTAssertNil(sut.window)
     }
@@ -337,8 +369,8 @@ private extension SnackContainerViewTests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> SnackContainerViewSpy {
-        let sut = SnackContainerViewSpy(alignment: alignment, appearance: SnackbarManager.Appearance())
-        trackForMemoryLeaks(sut, file: file, line: line)
+        let sut = SnackContainerViewSpy(alignment: alignment, appearance: .default)
+        trackForMemoryLeak(sut, file: file, line: line)
         return sut
     }
 

--- a/Tests/YSnackbarTests/Views/SnackViewTests.swift
+++ b/Tests/YSnackbarTests/Views/SnackViewTests.swift
@@ -78,7 +78,7 @@ final class SnackViewTests: XCTestCase {
             reuseIdentifier: "yml.com.snackbar1",
             icon: UIImage.make(withColor: .red),
             duration: 5,
-            appearance: SnackView.Appearance()
+            appearance: .default
         )
 
         let sut = makeSUT(snack: snack)
@@ -126,7 +126,7 @@ private extension SnackViewTests {
     ) -> SnackView {
         let sut = SnackView(snack: snack)
         sut.frame = CGRect(x: .zero, y: .zero, width: 300, height: 100)
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
         return sut
     }
 


### PR DESCRIPTION
## Introduction ##

We declared an appearance property on `SnackbarManager` but forgot that we don't have any way for users to interact with a specific instance of a manager. Everything is through class / static functions.

## Purpose ##

Fix #7 Make `SnackbarManager.appearance` static

## Scope ##

* Refactor SnackbarManager
* Refactor Appearance objects as structs
* Add unit tests

## Discussion ##

In addition to the main task, I made several changes to bring this library in line with our other UI libraries. Namely:
1. Converted the two `Appearance` objects from class to struct
2. Added a `static var default: Appearance` property to each of them as syntactic sugar.
3. Made the properties of `SnackbarManager.Appearance` var's for ease of use (this doesn't matter for the other appearance because the `Snack` model object is immutable.
4. Increased test coverage for a couple areas that were missing it

I also fixed a bug where the container view didn't have the correct appearance. Unit tests allowed me to find this!

## 📱 Screenshots ##

Actual appearance of Snack views should be unchanged.

## 📈 Coverage ##

##### Code #####

97.3%
<img width="629" alt="image" src="https://user-images.githubusercontent.com/1037520/226935249-9c496073-044e-4cf8-85fa-2aedd7e8fe8a.png">

##### Documentation #####

100%
<img width="585" alt="image" src="https://user-images.githubusercontent.com/1037520/226935947-e427d549-9366-42cb-8b32-680cd79d62d1.png">
