### PR TITLE
[Issue 6] Add dependencies to README

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/yml-org/YCoreUI.git",
-            from: "1.4.0"
+            from: "1.5.0"
         ),
         .package(
             url: "https://github.com/yml-org/YMatterType.git",
-            from: "1.4.0"
+            from: "1.6.0"
         )
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ Every snack added has the following default features:
     }
     ```
 
+Dependencies
+----------
+
+Y—Snackbar depends upon our [Y—CoreUI](https://github.com/yml-org/ycoreui) and [Y—MatterType](https://github.com/yml-org/ymattertype) frameworks (both also open source and Apache 2.0 licensed).
+
 Installation
 ----------
 


### PR DESCRIPTION
## Introduction ##

We should explicitly mention (and link) our dependencies in our libraries.

## Purpose ##

Fix #6 Add a Dependencies section to project README

## Scope ##

* Update README

## Discussion ##

* Also bumped Package file to include the latest YCoreUI and YMatterType, both of which have bug fixes that YSnackbar could use.

## 📈 Coverage ##

Code and documentation are both unchanged