### PR TITLE
[Issue 2] Add Border styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ Clients can modify or set the appearance of the `SnackView` while creating a `Sn
     - A tuple consisting of `textColor` and `typography` for the message label.
     - Default is `(.label, .systemLabel)` .
 - `backgroundColor`:
-    - `SnackView`'s background color. The default is `systemBackground`.
-- `shadow`:
-    - `SnackView`'s shadow property is of type `Shadow` and consists of properties such as color, opacity, etc.
-    - The default is `Shadow()`.
+    - Background color. The default is `systemBackground`.
+- `borderColor`:
+    - Border color. The default is `.label`.
+- `borderWidth`:
+    - Border width. The default is `0`.
+- `elevation`:
+    - Elevation (also known as box shadow). Default is `Appearance.elevation`.
 - `layout`:
-    - `SnackView`'s layout property is of type `Layout` which consists of properties such as spacing between views, corner radius, etc.
-    - The default is `Layout()`.
+    - Layout properties such as spacing between views, corner radius. Default is `Layout()`.
 
 **How to get `SnackView` from a `Snack`?**
 

--- a/Sources/YSnackbar/Views/SnackHostView.swift
+++ b/Sources/YSnackbar/Views/SnackHostView.swift
@@ -23,7 +23,7 @@ final class SnackHostView: UIView {
         }
     }
     
-    private let snackView: SnackUpdatable
+    internal let snackView: SnackUpdatable
     private var shadowSize: CGSize = .zero
 
     internal init(snackView: SnackUpdatable) {
@@ -65,6 +65,11 @@ final class SnackHostView: UIView {
 
     internal func updateShadow() {
         snack.appearance.elevation.apply(layer: layer, cornerRadius: snack.appearance.layout.cornerRadius)
+    }
+
+    internal func updateBorder() {
+        snackView.layer.borderWidth = snack.appearance.borderWidth
+        snackView.layer.borderColor = snack.appearance.borderColor.resolvedColor(with: traitCollection).cgColor
     }
     
     override func layoutSubviews() {
@@ -109,6 +114,7 @@ private extension SnackHostView {
 
     func updateView() {
         updateShadow()
+        updateBorder()
         snackView.layer.cornerRadius = snack.appearance.layout.cornerRadius
     }
 
@@ -118,7 +124,8 @@ private extension SnackHostView {
     
     func adjustColors() {
         let elevation = snack.appearance.elevation
-        layer.shadowColor = elevation.color.cgColor
+        layer.shadowColor = elevation.color.resolvedColor(with: traitCollection).cgColor
+        updateBorder()
     }
 }
 

--- a/Sources/YSnackbar/Views/SnackView+Appearance.swift
+++ b/Sources/YSnackbar/Views/SnackView+Appearance.swift
@@ -19,11 +19,15 @@ extension SnackView {
         /// A tuple consisting of `textColor` and `typography` for the message label.
         /// Default is `(.label, .systemLabel)`.
         public let message: (textColor: UIColor, typography: Typography)
-        /// `SnackView`'s background color. Default is `Appearance.snackBackgroundColor`.
+        /// Background color. Default is `Appearance.snackBackgroundColor`.
         public let backgroundColor: UIColor
-        /// `SnackView`'s elevation. Default is `Appearance.elevation`.
+        /// Border color. Default is `.label`.
+        public let borderColor: UIColor
+        /// Border width. Default is `0`.
+        public let borderWidth: CGFloat
+        /// Elevation (also known as box shadow). Default is `Appearance.elevation`.
         public let elevation: Elevation
-        /// `SnackView`'s layout properties such as spacing between views, corner radius. Default is `Layout()`.
+        /// Layout properties such as spacing between views, corner radius. Default is `Layout()`.
         public let layout: Layout
 
         /// Default appearance
@@ -32,23 +36,28 @@ extension SnackView {
         /// Initializes a `Appearance`.
         /// - Parameters:
         ///   - title: tuple consisting of `textColor` and `typography` for the title label.
-        ///     Default is `(.label, .systemLabel.bold)`
+        ///     Default is `(.label, .systemLabel.bold)`.
         ///   - message: tuple consisting of `textColor` and `typography` for the message label.
-        ///     Default is `(.label, .systemLabel)`
-        ///   - backgroundColor: `SnackView`'s background color. Default is `Appearance.snackBackgroundColor`
-        ///   - elevation: `SnackView`'s elevation. Default is `Appearance.elevation`
-        ///   - layout: `SnackView`'s layout properties such as spacing between views, corner radius.
-        ///     Default is `Layout()`
+        ///     Default is `(.label, .systemLabel)`.
+        ///   - backgroundColor: background color. Default is `Appearance.snackBackgroundColor`.
+        ///   - borderColor: border color
+        ///   - borderWidth: border width
+        ///   - elevation: elevation (box shadow). Default is `Appearance.elevation`.
+        ///   - layout: layout properties such as spacing between views, corner radius. Default is `Layout()`.
         public init(
             title: (textColor: UIColor, typography: Typography) =  (.label, .systemLabel.bold),
             message: (textColor: UIColor, typography: Typography) = (.label, .systemLabel),
             backgroundColor: UIColor = Appearance.snackBackgroundColor,
+            borderColor: UIColor = .label,
+            borderWidth: CGFloat = 0,
             elevation: Elevation = Appearance.elevation,
             layout: Layout = Layout()
         ) {
             self.title = title
             self.message = message
             self.backgroundColor = backgroundColor
+            self.borderColor = borderColor
+            self.borderWidth = borderWidth
             self.elevation = elevation
             self.layout = layout
         }

--- a/Tests/YSnackbarTests/Views/SnackHostViewTests.swift
+++ b/Tests/YSnackbarTests/Views/SnackHostViewTests.swift
@@ -219,8 +219,9 @@ final class SnackHostViewTests: XCTestCase {
 
     func test_changeColorSpace_updatesShadowColor() {
         // Given
-        let sut = makeSUT()
-        let elevation = sut.snack.appearance.elevation
+        let elevation = makeElevation(color: .systemPurple)
+        let appearance = SnackView.Appearance(elevation: elevation)
+        let sut = makeSUT(appearance: appearance)
         let (parent, child) = makeNestedViewControllers(subview: sut)
 
         UITraitCollection.allColorSpaces.forEach {
@@ -230,6 +231,23 @@ final class SnackHostViewTests: XCTestCase {
 
             // Then
             XCTAssertEqual(sut.layer.shadowColor, elevation.color.resolvedColor(with: $0).cgColor)
+        }
+    }
+
+    func test_changeColorSpace_updatesBorderColor() {
+        // Given
+        let appearance = SnackView.Appearance(borderColor: .systemPink, borderWidth: 2)
+        let sut = makeSUT(appearance: appearance)
+        let (parent, child) = makeNestedViewControllers(subview: sut)
+
+        UITraitCollection.allColorSpaces.forEach {
+            // When
+            parent.setOverrideTraitCollection($0, forChild: child)
+            sut.traitCollectionDidChange($0)
+
+            // Then
+            XCTAssertEqual(sut.snackView.layer.borderColor, appearance.borderColor.resolvedColor(with: $0).cgColor)
+            XCTAssertEqual(sut.snackView.layer.borderWidth, 2)
         }
     }
 

--- a/Tests/YSnackbarTests/Views/SnackViewAppearanceTests.swift
+++ b/Tests/YSnackbarTests/Views/SnackViewAppearanceTests.swift
@@ -23,6 +23,8 @@ final class SnackViewAppearanceTests: XCTestCase {
         XCTAssertEqual(sut.message.typography.fontSize, UIFont.labelFontSize)
         XCTAssertEqual(sut.message.typography.fontWeight, .regular)
 
+        XCTAssertEqual(sut.borderColor, .label)
+        XCTAssertEqual(sut.borderWidth, 0)
         XCTAssertEqual(sut.elevation, makeElevation())
         XCTAssertEqual(sut.layout, SnackView.Appearance.Layout())
         


### PR DESCRIPTION
## Introduction ##

PWC design calls for toasts (snackbars) with borders. We need to add the ability to style borders.

## Purpose ##

Fix #2 Add border styling ability to YSnackbar

## Scope ##

* Add border properties to `SnackView.Appearance`
* Set the borders in `SnackHostView`
* Cover new code in unit tests

## Discussion ##

Originally I thought the defaults should be `borderColor = nil` and `borderWidth = 1`, but then after looking at CALayer (which has defaults of `.black` and `0`, respectively), I decided that we should match that (except that we use `.label` instead of `.black` so that our default appearance can be dark mode compatible.

## 📱 Screenshots ##

| Light | Dark |
| --- | --- |
| ![sb_2_after_light](https://user-images.githubusercontent.com/1037520/227512941-14367187-5a11-4789-a943-5ab358a41bfc.png) | ![sb_2_after_dark](https://user-images.githubusercontent.com/1037520/227512935-5b4c6407-34fb-4ec5-9fa0-2b40f23b4810.png) |

## 📈 Coverage ##

##### Code #####

98.7%
<img width="620" alt="image" src="https://user-images.githubusercontent.com/1037520/227513381-2a16b7d9-0d58-4bb4-9ccd-58a1b53d8c40.png">

##### Documentation #####

100%
<img width="581" alt="image" src="https://user-images.githubusercontent.com/1037520/227513187-a9643dd1-54ea-445c-b2d0-3346f30b5a08.png">
