### PR TITLE
[Issue 11] Improve Snack Appearance object

### DIFF
--- a/Sources/YSnackbar/Model/Snack+Appearance+Layout.swift
+++ b/Sources/YSnackbar/Model/Snack+Appearance+Layout.swift
@@ -1,5 +1,5 @@
 //
-//  SnackView.Appearance+Layout.swift
+//  Snack+Appearance+Layout.swift
 //  YSnackbar
 //
 //  Created by Karthik K Manoj on 07/09/22.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension SnackView.Appearance {
+extension Snack.Appearance {
     /// A collection of layout properties for the `SnackView`.
     public struct Layout: Equatable {
         /// The custom distance the content is inset from the `SnackView`.

--- a/Sources/YSnackbar/Model/Snack+Appearance.swift
+++ b/Sources/YSnackbar/Model/Snack+Appearance.swift
@@ -1,5 +1,5 @@
 //
-//  SnackView+Appearance.swift
+//  Snack+Appearance.swift
 //  YSnackbar
 //
 //  Created by Karthik K Manoj on 07/09/22.
@@ -10,9 +10,9 @@ import UIKit
 import YMatterType
 import YCoreUI
 
-extension SnackView {
+extension Snack {
     /// A collection of properties to set the appearance of the `SnackView`.
-    public struct Appearance {
+    open class Appearance {
         /// A tuple consisting of `textColor` and `typography` for the title label.
         /// Default is `(.label, .systemLabel.bold)`.
         public let title: (textColor: UIColor, typography: Typography)
@@ -64,12 +64,13 @@ extension SnackView {
     }
 }
 
-extension SnackView.Appearance {
-    /// Creates snack view's background color dynamically
-    public static let snackBackgroundColor = UIColor(dynamicProvider: colorBasedOnTraitCollection)
-    
-    internal static func colorBasedOnTraitCollection(_ traitCollection: UITraitCollection) -> UIColor {
-        traitCollection.userInterfaceStyle == .dark ? .tertiarySystemBackground : .systemBackground
+extension Snack.Appearance {
+    /// Snack view default background color
+    public static let snackBackgroundColor = UIColor { (traitCollection: UITraitCollection) -> UIColor in
+        switch traitCollection.userInterfaceStyle {
+        case .dark: return .tertiarySystemBackground
+        default:    return .systemBackground
+        }
     }
     
     /// Creates a default elevation.

--- a/Sources/YSnackbar/Model/Snack.swift
+++ b/Sources/YSnackbar/Model/Snack.swift
@@ -23,7 +23,7 @@ open class Snack {
     /// The total duration for how long the snack to be displayed. Default is 4 seconds.
     public let duration: TimeInterval
     /// Appearance for the snack view such as background color, shadow etc. Default is `.default`.
-    public let appearance: SnackView.Appearance
+    public let appearance: Snack.Appearance
 
     /// Initializes a `Snack`.
     /// - Parameters:
@@ -42,7 +42,7 @@ open class Snack {
         reuseIdentifier: String? = nil,
         icon: UIImage? = nil,
         duration: TimeInterval = 4,
-        appearance: SnackView.Appearance = .default
+        appearance: Snack.Appearance = .default
     ) {
         self.alignment = alignment
         self.title = title

--- a/Sources/YSnackbar/Views/SnackView.swift
+++ b/Sources/YSnackbar/Views/SnackView.swift
@@ -56,7 +56,7 @@ open class SnackView: UIView {
         return stackView
     }()
 
-    private var appearance: Appearance { snack.appearance }
+    private var appearance: Snack.Appearance { snack.appearance }
 
     /// Initializes a `SnackView`.
     /// - Parameter snack: data model to use

--- a/Tests/YSnackbarTests/Model/Snack+Appearance+LayoutTests.swift
+++ b/Tests/YSnackbarTests/Model/Snack+Appearance+LayoutTests.swift
@@ -1,5 +1,5 @@
 //
-//  SnackViewAppearanceLayoutTests.swift
+//  Snack+Appearance+LayoutTests.swift
 //  YSnackbar
 //
 //  Created by Karthik K Manoj on 07/09/22.
@@ -9,9 +9,9 @@
 import XCTest
 import YSnackbar
 
-final class SnackViewAppearanceLayoutTests: XCTestCase {
+final class SnackAppearanceLayoutTests: XCTestCase {
     func test_init_propertiesDefaultValue() {
-        let sut = SnackView.Appearance.Layout()
+        let sut = Snack.Appearance.Layout()
         XCTAssertEqual(sut.contentInset, NSDirectionalEdgeInsets(all: 16.0))
         XCTAssertEqual(sut.labelSpacing, 8.0)
         XCTAssertEqual(sut.iconToLabelSpacing, 16.0)

--- a/Tests/YSnackbarTests/Model/Snack+AppearanceTests.swift
+++ b/Tests/YSnackbarTests/Model/Snack+AppearanceTests.swift
@@ -1,5 +1,5 @@
 //
-//  SnackViewAppearanceTests.swift
+//  Snack+AppearanceTests.swift
 //  YSnackbar
 //
 //  Created by Karthik K Manoj on 07/09/22.
@@ -10,9 +10,9 @@ import XCTest
 import YMatterType
 @testable import YSnackbar
 
-final class SnackViewAppearanceTests: XCTestCase {
+final class SnackAppearanceTests: XCTestCase {
     func test_init_propertiesDefaultValue() {
-        let sut = SnackView.Appearance()
+        let sut = makeSUT()
         XCTAssertEqual(sut.title.textColor, .label)
         XCTAssertEqual(sut.title.typography.fontFamily.familyName, Typography.systemFamily.familyName)
         XCTAssertEqual(sut.title.typography.fontSize, UIFont.labelFontSize)
@@ -26,7 +26,7 @@ final class SnackViewAppearanceTests: XCTestCase {
         XCTAssertEqual(sut.borderColor, .label)
         XCTAssertEqual(sut.borderWidth, 0)
         XCTAssertEqual(sut.elevation, makeElevation())
-        XCTAssertEqual(sut.layout, SnackView.Appearance.Layout())
+        XCTAssertEqual(sut.layout, Snack.Appearance.Layout())
         
         let sutRgba = sut.backgroundColor.rgbaComponents
         let systemRgba = UIColor.systemBackground.rgbaComponents
@@ -38,15 +38,32 @@ final class SnackViewAppearanceTests: XCTestCase {
         XCTAssertTrue(systemRgba.alpha == sutRgba.alpha || tertiarySystemRgba.alpha == sutRgba.alpha)
     }
     
-    func test_colorBasedOnTraitCollection_deliversTertiarySystemBackgroundColorOnDarkMode() {
+    func test_snackbarBackgroundColor_deliversTertiarySystemBackgroundColorOnDarkMode() {
         let trait = UITraitCollection(userInterfaceStyle: .dark)
         
-        XCTAssertEqual(SnackView.Appearance.colorBasedOnTraitCollection(trait), .tertiarySystemBackground)
+        XCTAssertEqual(
+            Snack.Appearance.snackBackgroundColor.resolvedColor(with: trait),
+            .tertiarySystemBackground.resolvedColor(with: trait)
+        )
     }
     
-    func test_colorBasedOnTraitCollection_deliversSystemBackgroundColorOnLightMode() {
+    func test_snackbarBackgroundColor_deliversSystemBackgroundColorOnLightMode() {
         let trait = UITraitCollection(userInterfaceStyle: .light)
         
-        XCTAssertEqual(SnackView.Appearance.colorBasedOnTraitCollection(trait), .systemBackground)
+        XCTAssertEqual(
+            Snack.Appearance.snackBackgroundColor.resolvedColor(with: trait),
+            .systemBackground.resolvedColor(with: trait)
+        )
+    }
+}
+
+extension SnackAppearanceTests {
+    func makeSUT(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Snack.Appearance {
+        let sut = Snack.Appearance()
+        trackForMemoryLeak(sut, file: file, line: line)
+        return sut
     }
 }

--- a/Tests/YSnackbarTests/Model/SnackTests.swift
+++ b/Tests/YSnackbarTests/Model/SnackTests.swift
@@ -50,7 +50,7 @@ final class SnackTests: XCTestCase {
         XCTAssertEqual(appearance.message.typography.fontWeight, .regular)
 
         XCTAssertEqual(appearance.elevation, makeElevation())
-        XCTAssertEqual(appearance.layout, SnackView.Appearance.Layout())
+        XCTAssertEqual(appearance.layout, Snack.Appearance.Layout())
         
         let expectedRgba = appearance.backgroundColor.rgbaComponents
         let systemRgba = UIColor.systemBackground.rgbaComponents

--- a/Tests/YSnackbarTests/Views/SnackHostViewTests.swift
+++ b/Tests/YSnackbarTests/Views/SnackHostViewTests.swift
@@ -144,7 +144,7 @@ final class SnackHostViewTests: XCTestCase {
 
     func test_updateShadow_doesNotSetShadowPathWhenUseShadowPathIsFalse() {
         let elevation = makeElevation(useShadowPath: false)
-        let appearance = SnackView.Appearance(elevation: elevation)
+        let appearance = Snack.Appearance(elevation: elevation)
         let sut = makeSUT(appearance: appearance)
         sut.bounds = CGRect(origin: .zero, size: CGSize(width: 1, height: 1))
 
@@ -155,7 +155,7 @@ final class SnackHostViewTests: XCTestCase {
 
     func test_updateShadow_setsShadowPathWhenUseShadowPathIsTrue() {
         let elevation = makeElevation(useShadowPath: true)
-        let appearance = SnackView.Appearance(elevation: elevation)
+        let appearance = Snack.Appearance(elevation: elevation)
         let sut = makeSUT(appearance: appearance)
         sut.bounds = CGRect(origin: .zero, size: CGSize(width: 1, height: 1))
 
@@ -171,8 +171,8 @@ final class SnackHostViewTests: XCTestCase {
 
         let shadowPath = try XCTUnwrap(sut.layer.shadowPath)
 
-        let layout = SnackView.Appearance.Layout(cornerRadius: 16)
-        let appearance = SnackView.Appearance(layout: layout)
+        let layout = Snack.Appearance.Layout(cornerRadius: 16)
+        let appearance = Snack.Appearance(layout: layout)
         let newSnack = Snack(message: "", appearance: appearance)
 
         sut.update(newSnack)
@@ -202,10 +202,10 @@ final class SnackHostViewTests: XCTestCase {
         XCTAssertEqual(sut.layer.shadowOffset, CGSize(width: 0, height: 2.33))
         XCTAssertEqual(sut.layer.shadowRadius, elevation.blur / 2.5)
         
-        let layout = SnackView.Appearance.Layout(cornerRadius: 16)
+        let layout = Snack.Appearance.Layout(cornerRadius: 16)
         let newElevation = makeElevation(xOffset: 2, yOffset: 2, blur: 36, spread: 0, color: .red, opacity: 1.0)
         
-        let appearance = SnackView.Appearance(elevation: newElevation, layout: layout)
+        let appearance = Snack.Appearance(elevation: newElevation, layout: layout)
         let newSnack = Snack(message: "", appearance: appearance)
         
         sut.update(newSnack)
@@ -220,7 +220,7 @@ final class SnackHostViewTests: XCTestCase {
     func test_changeColorSpace_updatesShadowColor() {
         // Given
         let elevation = makeElevation(color: .systemPurple)
-        let appearance = SnackView.Appearance(elevation: elevation)
+        let appearance = Snack.Appearance(elevation: elevation)
         let sut = makeSUT(appearance: appearance)
         let (parent, child) = makeNestedViewControllers(subview: sut)
 
@@ -236,7 +236,7 @@ final class SnackHostViewTests: XCTestCase {
 
     func test_changeColorSpace_updatesBorderColor() {
         // Given
-        let appearance = SnackView.Appearance(borderColor: .systemPink, borderWidth: 2)
+        let appearance = Snack.Appearance(borderColor: .systemPink, borderWidth: 2)
         let sut = makeSUT(appearance: appearance)
         let (parent, child) = makeNestedViewControllers(subview: sut)
 
@@ -268,7 +268,7 @@ final class SnackHostViewTests: XCTestCase {
 
 private extension SnackHostViewTests {
     func makeSUT(
-        appearance: SnackView.Appearance = .default,
+        appearance: Snack.Appearance = .default,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> SnackHostView {

--- a/Tests/YSnackbarTests/Views/SnackViewTests.swift
+++ b/Tests/YSnackbarTests/Views/SnackViewTests.swift
@@ -90,7 +90,7 @@ final class SnackViewTests: XCTestCase {
         XCTAssertEqual(sut.snack.duration, snack.duration)
         XCTAssertEqual(sut.snack.appearance, snack.appearance)
 
-        let newAppearance = SnackView.Appearance(
+        let newAppearance = Snack.Appearance(
             title: (textColor: .red, typography: .systemLabel),
             message: (textColor: .red, typography: .systemLabel),
             backgroundColor: .blue,
@@ -141,7 +141,7 @@ private extension SnackViewTests {
         reuseIdentifier: String?,
         icon: UIImage?,
         duration: TimeInterval,
-        appearance: SnackView.Appearance
+        appearance: Snack.Appearance
     ) -> Snack {
         Snack(
             title: title,
@@ -153,8 +153,8 @@ private extension SnackViewTests {
         )
     }
 
-    func makeFixedLayout() -> SnackView.Appearance.Layout {
-        SnackView.Appearance.Layout(
+    func makeFixedLayout() -> Snack.Appearance.Layout {
+        Snack.Appearance.Layout(
             contentInset: NSDirectionalEdgeInsets(all: 8.0),
             labelSpacing: 16.0,
             iconToLabelSpacing: 16.0,
@@ -165,8 +165,8 @@ private extension SnackViewTests {
 }
 
 // Test Helper
-extension SnackView.Appearance: Equatable {
-    public static func == (lhs: SnackView.Appearance, rhs: SnackView.Appearance) -> Bool {
+extension Snack.Appearance: Equatable {
+    public static func == (lhs: Snack.Appearance, rhs: Snack.Appearance) -> Bool {
         (lhs.title.textColor == rhs.title.textColor) &&
         (lhs.title.typography.fontFamily.familyName == rhs.title.typography.fontFamily.familyName) &&
         (lhs.title.typography.fontSize == rhs.title.typography.fontSize) &&


### PR DESCRIPTION
## Introduction ##

Because we allow users to subclass `Snack`, it also makes sense to allow them to subclass the snack's appearance.

## Purpose ##

Fix #11 Make YSnackbar more extensible by making the snack appearance an `open class`.

## Scope ##

* Move SnackView.Appearance to Snack.Appearance (and Layout similarly)
* Convert Snack.Appearance from struct to class
* Move and rename matching unit test cases accordingly

## Discussion ##

I also cleaned up the definition of Appearance.snackbarBackgroundColor which was unnecessarily calling another function.

Technically this is a breaking change, but should be a relatively minor one. (Requested by Karthik to support work on a toast view.)

## 📱 Screenshots ##

Snackbar appearance is unchanged

## 🎬 Video ##

Snackbar behavior is unchanged

## 📈 Coverage ##

##### Code #####

98.7%
<img width="608" alt="image" src="https://user-images.githubusercontent.com/1037520/227931782-b10cc868-80a3-4096-aa64-cf07b4e15b38.png">

##### Documentation #####

100%
<img width="595" alt="image" src="https://user-images.githubusercontent.com/1037520/227931886-adda3fc1-25f6-4242-a40f-e46d39666257.png">
