### PR TITLE
[Issue 5] Support Reduce Motion Accessibility Setting

### DIFF
--- a/Sources/YSnackbar/Views/SnackContainerView+Add.swift
+++ b/Sources/YSnackbar/Views/SnackContainerView+Add.swift
@@ -1,0 +1,83 @@
+//
+//  SnackContainerView+Add.swift
+//  YSnackbar
+//
+//  Created by Mark Pospesel on 3/27/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import UIKit
+
+internal extension SnackContainerView {
+    func addHostViewWithInitialAppearance(_ hostView: SnackHostView) {
+        addSubview(hostView)
+        setupInitialConstraints(for: hostView)
+        if !isReduceMotionEnabled {
+            updateConstraintsOnAdding(hostView: hostView)
+        }
+        linkHostViewsOnAdding(hostView: hostView)
+
+        switch alignment {
+        case .top:
+            hostViews.append(hostView)
+        case .bottom:
+            hostViews.insert(hostView, at: .zero)
+        }
+    }
+}
+
+private extension SnackContainerView {
+    func setupInitialConstraints(for hostView: SnackHostView) {
+        guard let superview = superview else { return }
+
+        let constraint: NSLayoutConstraint?
+
+        if isReduceMotionEnabled {
+            // put the view into its final position
+            constraint = nil
+            updateConstraintsOnAdding(hostView: hostView)
+            hostView.alpha = 0
+        } else {
+            switch alignment {
+            case .top:
+                let offset = max(hostView.snack.appearance.elevation.extent.bottom, 0)
+                constraint = hostView.constrain(.bottomAnchor, to: superview.topAnchor, constant: -offset)
+            case .bottom:
+                let offset = max(hostView.snack.appearance.elevation.extent.top, 0)
+                constraint = hostView.constrain(.topAnchor, to: superview.bottomAnchor, constant: offset)
+            }
+        }
+
+        hostView.constrain(.leadingAnchor, to: leadingAnchor)
+        hostView.constrain(.trailingAnchor, to: trailingAnchor)
+
+        layoutIfNeeded()
+
+        constraint?.isActive = false
+    }
+
+    func updateConstraintsOnAdding(hostView: SnackHostView) {
+        let latestHostView = latestHostView
+
+        switch alignment {
+        case .top:
+            hostView.setTopConstraint(hostView.constrain(
+                .topAnchor,
+                to: latestHostView?.bottomAnchor ?? topAnchor,
+                constant: latestHostView == nil ? .zero : appearance.snackSpacing
+            ))
+        case .bottom:
+            hostView.setBottomConstraint(hostView.constrain(
+                .bottomAnchor,
+                to: latestHostView?.topAnchor ?? bottomAnchor,
+                constant: latestHostView == nil ? .zero : -appearance.snackSpacing
+            ))
+        }
+    }
+
+    func linkHostViewsOnAdding(hostView: SnackHostView) {
+        let latestHostView = latestHostView
+        hostView.setPreviousHostView(latestHostView)
+        latestHostView?.setNextHostView(hostView)
+    }
+}


### PR DESCRIPTION
## Introduction ##

We should honor the Accessibility Reduce Motion setting when it is enabled and use cross-fade animations instead of sliding the snackbars on and off screen.

## Purpose ##

Fix #5 Use cross-fade animations when Reduce Motion is enabled

## Scope ##

* Update `SnackContainerView` to honor the Reduce Motion setting
* Update unit tests

## Discussion ##

`SnackContainerView.swift` got too large, so I extracted the Add specific code to a separate file. Later it would be nice to do the same thing for Remove and Rearrange animations.

## 🎬 Video ##

**Note:** Strictly for the purposes of these GIF's, I doubled the animation duration (otherwise it's hard to capture).

| Reduced Motion Off | Reduced Motion On |
| --- | --- |
| ![sb_5_reduce_off](https://user-images.githubusercontent.com/1037520/227989222-d6d1b73d-711c-4929-ab30-f272279485d8.gif) | ![sb_5_reduce_on](https://user-images.githubusercontent.com/1037520/227989249-07460bcd-0d1f-4262-8d95-9e680e5fb0f4.gif) |

## 📈 Coverage ##

##### Code #####

99.1% (Higher than previously)
<img width="630" alt="image" src="https://user-images.githubusercontent.com/1037520/227990610-844396fa-74cd-47b0-aab1-031506f80631.png">

##### Documentation #####

100%
<img width="582" alt="image" src="https://user-images.githubusercontent.com/1037520/227990739-7e829676-7930-45d7-b1f9-533a8711ab19.png">
