### PR TITLE
[Issue 1] Add animation parameters

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/yml-org/YCoreUI.git",
-            from: "1.5.0"
+            from: "1.6.0"
         ),
         .package(
             url: "https://github.com/yml-org/YMatterType.git",

--- a/Sources/YSnackbar/Manager/SnackbarManager+Appearance.swift
+++ b/Sources/YSnackbar/Manager/SnackbarManager+Appearance.swift
@@ -7,19 +7,22 @@
 //
 
 import UIKit
+import YCoreUI
 
 extension SnackbarManager {
     /// Control animation duration and spacing
     public struct Appearance: Equatable {
-        /// Animation duration on adding a snack. Default is `0.4`
-        public var addAnimationDuration: TimeInterval
-        /// Animation duration on removing a snack. Default is `0.4`
-        public var removeAnimationDuration: TimeInterval
-        /// Spacing between snacks. Default is `16.0`
+        /// Animation for adding a snack. Default = `.defaultAdd`.
+        public var addAnimation: Animation
+        /// Animation for rearranging snacks. Default = `.defaultRearrange`.
+        public var rearrangeAnimation: Animation
+        /// Animation for removing a snack. Default = `.defaultRemove`.
+        public var removeAnimation: Animation
+        /// Spacing between snacks. Default is `16.0`.
         public var snackSpacing: CGFloat
-        /// Distance the content is inset from the superview. Default is `NSDirectionalEdgeInsets(all: 16.0)`
+        /// Distance the content is inset from the superview. Default is `NSDirectionalEdgeInsets(all: 16.0)`.
         public var contentInset: NSDirectionalEdgeInsets
-        /// Maximum width of a snack view. Default is `428.0`
+        /// Maximum width of a snack view. Default is `428.0`.
         public var maxSnackWidth: CGFloat
 
         /// Default appearance
@@ -27,21 +30,24 @@ extension SnackbarManager {
 
         /// Initializes a snackbar manager's appearance
         /// - Parameters:
-        ///   - addAnimationDuration: animation duration on adding a snack. Default is `0.4`
-        ///   - removeAnimationDuration: animation duration on removing a snack. Default is `0.4`
+        ///   - addAnimation: animation for adding a snack. Default is `.defaultAdd`,
+        ///   - rearrangeAnimation: animation for rearranging snacks. Default is `.defaultRearrange`.
+        ///   - removeAnimation: animation for removing a snack. Default is `.defaultRemove`.
         ///   - snackSpacing: spacing between snacks. Default is `16.0`
         ///   - contentInset: distance the content is inset from the superview
         ///     Default is `NSDirectionalEdgeInsets(all: 16.0)`
         ///   - maxSnackWidth: maximum width of a snack view. Default is `428.0`
         public init(
-            addAnimationDuration: TimeInterval = 0.4,
-            removeAnimationDuration: TimeInterval = 0.4,
+            addAnimation: Animation = .defaultAdd,
+            rearrangeAnimation: Animation = .defaultRearrange,
+            removeAnimation: Animation = .defaultRemove,
             snackSpacing: CGFloat = 16.0,
             contentInset: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(all: 16.0),
             maxSnackWidth: CGFloat = 428.0
         ) {
-            self.addAnimationDuration = addAnimationDuration
-            self.removeAnimationDuration = removeAnimationDuration
+            self.addAnimation = addAnimation
+            self.rearrangeAnimation = rearrangeAnimation
+            self.removeAnimation = removeAnimation
             self.snackSpacing = snackSpacing
             self.contentInset = contentInset
             self.maxSnackWidth = maxSnackWidth

--- a/Sources/YSnackbar/Model/Animation+Snackbar.swift
+++ b/Sources/YSnackbar/Model/Animation+Snackbar.swift
@@ -1,0 +1,22 @@
+//
+//  Animation+Snackbar.swift
+//  YSnackbar
+//
+//  Created by Mark Pospesel on 3/31/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import UIKit
+import YCoreUI
+
+/// Default animation properties for snackbar operations
+public extension Animation {
+    /// Default animation for adding a snack (spring)
+    static let defaultAdd = Animation(duration: 0.4, curve: .spring(damping: 0.6, velocity: 0.4))
+
+    /// Default animation for rearranging snacks (ease in, ease out)
+    static let defaultRearrange = Animation()
+
+    /// Default animation for removing a snack (ease out)
+    static let defaultRemove = Animation(curve: .regular(options: .curveEaseOut))
+}

--- a/Sources/YSnackbar/Views/SnackContainerView.swift
+++ b/Sources/YSnackbar/Views/SnackContainerView.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import YCoreUI
 
 internal class SnackContainerView: UIView {
     internal let alignment: Alignment
@@ -34,10 +35,6 @@ internal class SnackContainerView: UIView {
     internal var appearance: SnackbarManager.Appearance
 
     internal var hostViews: [SnackHostView] = []
-
-    private var dampingRatio: CGFloat { 0.6 }
-    private var velocity: CGFloat { 0.4 }
-    internal var rearrangeAnimationDuration: CGFloat { 0.4 }
 
     /// Override for isReduceMotionEnabled. Default is `nil`.
     ///
@@ -86,7 +83,7 @@ internal class SnackContainerView: UIView {
             self.layoutIfNeeded()
             UIView.transition(
                 with: self,
-                duration: appearance.removeAnimationDuration,
+                duration: appearance.removeAnimation.duration,
                 options: .transitionCrossDissolve,
                 animations: {
                     hostView.alpha = 0
@@ -96,7 +93,7 @@ internal class SnackContainerView: UIView {
             }
         } else {
             UIView.animate(
-                withDuration: appearance.removeAnimationDuration,
+                with: appearance.removeAnimation,
                 animations: {
                     self.layoutIfNeeded()
                 }
@@ -128,7 +125,7 @@ internal class SnackContainerView: UIView {
             self.layoutIfNeeded()
             UIView.transition(
                 with: self,
-                duration: rearrangeAnimationDuration,
+                duration: appearance.rearrangeAnimation.duration,
                 options: .transitionCrossDissolve,
                 animations: { }
             ) { _ in
@@ -136,7 +133,7 @@ internal class SnackContainerView: UIView {
             }
         } else {
             UIView.animate(
-                withDuration: rearrangeAnimationDuration,
+                with: appearance.rearrangeAnimation,
                 animations: {
                     self.layoutIfNeeded()
                 }
@@ -215,10 +212,10 @@ private extension SnackContainerView {
 
     func performAddAnimation(on hostView: SnackHostView, completion: @escaping () -> Void) {
         if isReduceMotionEnabled {
-            UIView.animate(
-                withDuration: appearance.addAnimationDuration,
-                delay: .zero,
-                options: .curveEaseIn,
+            UIView.transition(
+                with: self,
+                duration: appearance.addAnimation.duration,
+                options: .transitionCrossDissolve,
                 animations: {
                     hostView.alpha = 1
                 }
@@ -227,10 +224,7 @@ private extension SnackContainerView {
             }
         } else {
             UIView.animate(
-                withDuration: appearance.addAnimationDuration,
-                delay: .zero,
-                usingSpringWithDamping: dampingRatio,
-                initialSpringVelocity: velocity,
+                with: appearance.addAnimation,
                 animations: {
                     self.layoutIfNeeded()
                 }

--- a/Tests/YSnackbarTests/Manager/SnackbarManagerBottomTests.swift
+++ b/Tests/YSnackbarTests/Manager/SnackbarManagerBottomTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import YCoreUI
 @testable import YSnackbar
 
 final class SnackbarManagerBottomTests: XCTestCase {
@@ -216,8 +217,9 @@ final class SnackbarManagerBottomTests: XCTestCase {
 
         sut.add(snack: Snack(message: ""))
 
-        XCTAssertEqual(sut.appearance.addAnimationDuration, 0.4)
-        XCTAssertEqual(sut.appearance.removeAnimationDuration, 0.4)
+        XCTAssertEqual(sut.appearance.addAnimation, .defaultAdd)
+        XCTAssertEqual(sut.appearance.rearrangeAnimation, .defaultRearrange)
+        XCTAssertEqual(sut.appearance.removeAnimation, .defaultRemove)
         XCTAssertEqual(sut.appearance.contentInset, NSDirectionalEdgeInsets(all: 16.0))
         XCTAssertEqual(sut.appearance.snackSpacing, 16.0)
         XCTAssertEqual(sut.appearance.maxSnackWidth, 428.0)
@@ -228,8 +230,9 @@ final class SnackbarManagerBottomTests: XCTestCase {
     func test_newAppearanceOnAddingSnackAtTheBottom() {
         let sut = makeSUT()
         let appearance = SnackbarManager.Appearance(
-            addAnimationDuration: 0.7,
-            removeAnimationDuration: 0.7,
+            addAnimation: Animation(duration: 0.6, curve: .regular(options: .curveEaseIn)),
+            rearrangeAnimation: Animation(duration: 0.7),
+            removeAnimation: Animation(duration: 0.8),
             snackSpacing: 24.0,
             contentInset: NSDirectionalEdgeInsets(all: 24.0)
         )

--- a/Tests/YSnackbarTests/Manager/SnackbarManagerTopTests.swift
+++ b/Tests/YSnackbarTests/Manager/SnackbarManagerTopTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import YCoreUI
 @testable import YSnackbar
 
 final class SnackbarManagerTopTests: XCTestCase {
@@ -255,8 +256,9 @@ final class SnackbarManagerTopTests: XCTestCase {
 
         sut.add(snack: Snack(message: ""))
 
-        XCTAssertEqual(sut.appearance.addAnimationDuration, 0.4)
-        XCTAssertEqual(sut.appearance.removeAnimationDuration, 0.4)
+        XCTAssertEqual(sut.appearance.addAnimation, .defaultAdd)
+        XCTAssertEqual(sut.appearance.rearrangeAnimation, .defaultRearrange)
+        XCTAssertEqual(sut.appearance.removeAnimation, .defaultRemove)
         XCTAssertEqual(sut.appearance.contentInset, NSDirectionalEdgeInsets(all: 16.0))
         XCTAssertEqual(sut.appearance.snackSpacing, 16.0)
         XCTAssertEqual(sut.appearance.maxSnackWidth, 428.0)
@@ -266,15 +268,15 @@ final class SnackbarManagerTopTests: XCTestCase {
 
     func test_newAppearanceOnAddingSnackAtTheTop() {
         let sut = makeSUT()
+        let otherAnimation = Animation(duration: 0.7, curve: .regular(options: .curveEaseIn))
         let appearance = SnackbarManager.Appearance(
-            addAnimationDuration: 0.7,
-            removeAnimationDuration: 0.7,
+            addAnimation: otherAnimation,
             snackSpacing: 24.0,
             contentInset: NSDirectionalEdgeInsets(all: 24.0)
         )
 
-        sut.appearance.addAnimationDuration = 0.7
-        sut.appearance.removeAnimationDuration = 0.7
+        sut.appearance.addAnimation.duration = 0.7
+        sut.appearance.addAnimation.curve = .regular(options: .curveEaseIn)
         sut.appearance.snackSpacing = 24.0
         sut.appearance.contentInset = NSDirectionalEdgeInsets(all: 24.0)
 

--- a/Tests/YSnackbarTests/Model/Animation+SnackbarTests.swift
+++ b/Tests/YSnackbarTests/Model/Animation+SnackbarTests.swift
@@ -1,0 +1,43 @@
+//
+//  Animation+SnackbarTests.swift
+//  YSnackbar
+//
+//  Created by Mark Pospesel on 3/31/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+import YCoreUI
+@testable import YSnackbar
+
+final class AnimationSnackbarTests: XCTestCase {
+    func test_defaultAdd() {
+        // Given
+        let sut = Animation.defaultAdd
+
+        // Then
+        XCTAssertEqual(sut.duration, 0.4)
+        XCTAssertEqual(sut.delay, 0.0)
+        XCTAssertEqual(sut.curve, .spring(damping: 0.6, velocity: 0.4))
+    }
+
+    func test_defaultRearrange() {
+        // Given
+        let sut = Animation.defaultRearrange
+
+        // Then
+        XCTAssertEqual(sut.duration, 0.3)
+        XCTAssertEqual(sut.delay, 0.0)
+        XCTAssertEqual(sut.curve, .regular(options: .curveEaseInOut))
+    }
+
+    func test_defaultRemove() {
+        // Given
+        let sut = Animation.defaultRemove
+
+        // Then
+        XCTAssertEqual(sut.duration, 0.3)
+        XCTAssertEqual(sut.delay, 0.0)
+        XCTAssertEqual(sut.curve, .regular(options: .curveEaseOut))
+    }
+}

--- a/Tests/YSnackbarTests/Views/SnackContainerViewTests.swift
+++ b/Tests/YSnackbarTests/Views/SnackContainerViewTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import YCoreUI
 @testable import YSnackbar
 
 // OK to have lots of test cases
@@ -24,11 +25,6 @@ final class SnackContainerViewTests: XCTestCase {
 
     func test_init_deliversBottomAlignment() {
         XCTAssertEqual(makeSUT(alignment: .bottom).alignment, .bottom)
-    }
-
-    func test_init_deliversRearrangeAnimationDuration() {
-        let sut = SnackContainerView(alignment: .top, appearance: .default)
-        XCTAssertEqual(sut.rearrangeAnimationDuration, 0.4)
     }
 
     func test_addSnackOnTop_isAddedToWindow() {
@@ -434,7 +430,8 @@ private extension SnackContainerViewTests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> SnackContainerViewSpy {
-        let appearance = SnackbarManager.Appearance(addAnimationDuration: 0, removeAnimationDuration: 0)
+        let none = Animation(duration: 0)
+        let appearance = SnackbarManager.Appearance(addAnimation: none, rearrangeAnimation: none, removeAnimation: none)
         let sut = SnackContainerViewSpy(alignment: alignment, appearance: appearance)
         sut.reduceMotionOverride = isReduceMotionEnabled
         trackForMemoryLeak(sut, file: file, line: line)
@@ -458,7 +455,6 @@ private extension SnackContainerViewTests {
 final class SnackContainerViewSpy: SnackContainerView {
     var snackViewToBeRemoved = UIView()
 
-    override var rearrangeAnimationDuration: CGFloat { 0.0 }
     override var keyWindow: UIWindow? { UIWindow() }
 
     override func removeHostViewWithAnimation(


### PR DESCRIPTION
## Introduction ##

We allow users to customize the duration of add and remove animations, but that's it. They can't control the curve used nor any aspects of the rearrange animations (when multiple snacks are reordered).

## Purpose ##

Fix #1 Allow full customization of animation duration and curve for add, rearrange, and remove animations.

## Scope ##

* Extend `Animation` with defaults for the 3 types of animations
* Refactor `SnackbarManager.Appearance` to hold 3 `Animation` objects for the 3 types of animations
* Modify `SnackContainerView` to use the new animations
* Update unit tests

## Discussion ##

The animation customization applies to the normal slide in / slide out animations. When Reduce Motion animation is on we will use cross-dissolve transitions that honor the duration only (curves and delays wouldn't really apply to cross-fade).

This is a breaking API change in SnackbarManager.Appearance, but should not be too burdensome.

There's also a slight behavior change: rearrange and remove animations have been reduced to `0.3` seconds. The add animation is `0.4` because it's a spring animation which takes longer to settle. For standard ease in/out animations, 0.3 is the standard default duration.

## 🎬 Video ##

Note: duration of these animations were slowed to 0.6 to better capture in GIF format
| Default animation | Spring animation |
| --- | --- |
| ![sb_1_before](https://user-images.githubusercontent.com/1037520/229163135-67e7cfff-8cc2-47dc-addc-da4881614b37.gif) | ![sb_1_after](https://user-images.githubusercontent.com/1037520/229163123-0cc41ed0-91e5-4179-9b6a-014cb03c0e07.gif) |

## 📈 Coverage ##

##### Code #####

99.1%
<img width="616" alt="image" src="https://user-images.githubusercontent.com/1037520/229163743-76715317-d1f7-4c9b-8818-d2eb2da6905a.png">

##### Documentation #####

100%
<img width="595" alt="image" src="https://user-images.githubusercontent.com/1037520/229163400-96f66c6a-d924-4491-9909-e9414b267d62.png">
