### PR TITLE
[CM-1384] Fix Swift 5.8 warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/yml-org/YCoreUI.git",
-            from: "1.6.0"
+            from: "1.7.0"
         ),
         .package(
             url: "https://github.com/yml-org/YMatterType.git",

--- a/Sources/YSnackbar/Model/Snack+Appearance+Layout.swift
+++ b/Sources/YSnackbar/Model/Snack+Appearance+Layout.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import YCoreUI
 
 extension Snack.Appearance {
     /// A collection of layout properties for the `SnackView`.

--- a/Tests/YSnackbarTests/Views/SnackContainerViewTests.swift
+++ b/Tests/YSnackbarTests/Views/SnackContainerViewTests.swift
@@ -11,8 +11,7 @@ import YCoreUI
 @testable import YSnackbar
 
 // OK to have lots of test cases
-// swiftlint:disable file_length
-// swiftlint:disable type_body_length
+// swiftlint:disable file_length type_body_length
 
 final class SnackContainerViewTests: XCTestCase {
     func test_initWithCoder() throws {
@@ -499,3 +498,4 @@ final class SnackContainerViewSpy: SnackContainerView {
         addHostViewWithInitialAppearance(view)
     }
 }
+// swiftlint:enable file_length type_body_length


### PR DESCRIPTION
## Introduction ##

Fix compiler warning added due to Swift 5.8.
## Purpose ##
Remove compiler warning.
Also updated dependency (YCoreUI) version 1.6.0 to 1.7.0.

Fix https://github.com/yml-org/ysnackbar-ios/issues/16
## Scope ##

`Snack+Appearance+Layout.swift` file update.

## Out of Scope ##

Any functionality or UI change.